### PR TITLE
Better scrolling for wrapped lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A plugin for the quickfix and location list windows to quickly preview the file
 with the quickfix item under the cursor in a popup window.
 
-**Note:** Plugin requires at least Vim `8.1.1705`.
+**Note:** Plugin requires at least Vim `8.1.2250`.
 
 <dl>
   <p align="center">
@@ -61,9 +61,6 @@ The following keys can be used while the popup window is visible:
 | <kbd>+</kbd>      | Increase height of popup window by one line.| -                       |
 | <kbd>-</kbd>      | Decrease height of popup window by one line.| -                       |
 
-**Note:** If your Vim is older than `8.1.1799` you will have to press
-<kbd>gg</kbd> to scroll to the top of the displayed buffer.
-
 
 ## Configuration
 
@@ -115,7 +112,7 @@ name. For more details see `:help packages`.
 Assuming [vim-plug](https://github.com/junegunn/vim-plug) is your favorite
 plugin manager, add the following to your `vimrc`:
 ```vim
-if has('patch-8.1.1705')
+if has('patch-8.1.2250')
     Plug 'bfrg/vim-qf-preview'
 endif
 ```

--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -3,7 +3,7 @@
 " File:         after/ftplugin/qf.vim
 " Author:       bfrg <https://github.com/bfrg>
 " Website:      https://github.com/bfrg/vim-qf-preview
-" Last Change:  Oct 28, 2019
+" Last Change:  Nov 5, 2019
 " License:      Same as Vim itself (see :h license)
 " ==============================================================================
 
@@ -11,7 +11,7 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 " Stop here if user doesn't want ftplugin mappings
-if exists('g:no_plugin_maps') || !has('patch-8.1.1705')
+if exists('g:no_plugin_maps') || !has('patch-8.1.2250')
     finish
 endif
 

--- a/autoload/qfpreview.vim
+++ b/autoload/qfpreview.vim
@@ -3,7 +3,7 @@
 " File:         autoload/qfpreview.vim
 " Author:       bfrg <https://github.com/bfrg>
 " Website:      https://github.com/bfrg/vim-qf-preview
-" Last Change:  Nov 5, 2019
+" Last Change:  Mar 16, 2020
 " License:      Same as Vim itself (see :h license)
 " ==============================================================================
 
@@ -12,16 +12,16 @@ scriptencoding utf-8
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:defaults = #{
-        \ height: 15,
-        \ scrollup: "\<c-k>",
-        \ scrolldown: "\<c-j>",
-        \ halfpageup: "\<c-u>",
-        \ halfpagedown: "\<c-d>",
-        \ fullpageup: "\<c-b>",
-        \ fullpagedown: "\<c-f>",
-        \ close: 'x',
-        \ mapping: v:false
+let s:defaults = {
+        \ 'height': 15,
+        \ 'scrollup': "\<c-k>",
+        \ 'scrolldown': "\<c-j>",
+        \ 'halfpageup': "\<c-u>",
+        \ 'halfpagedown': "\<c-d>",
+        \ 'fullpageup': "\<c-b>",
+        \ 'fullpagedown': "\<c-f>",
+        \ 'close': 'x',
+        \ 'mapping': v:false
         \ }
 
 function! s:get(key) abort
@@ -30,7 +30,7 @@ function! s:get(key) abort
 endfunction
 
 let s:mappings = {
-        \ 'g': {id -> popup_setoptions(id, #{firstline: 1})},
+        \ 'g': {id -> popup_setoptions(id, {'firstline': 1})},
         \ 'G': {id -> s:scroll(id, 'G')},
         \ '+': {id -> s:setheight(id, 1)},
         \ '-': {id -> s:setheight(id, -1)}
@@ -47,13 +47,13 @@ let s:mappings[s:get('close')]        = {id -> popup_close(id)}
 function! s:scroll(winid, cmd) abort
     call win_execute(a:winid, 'normal! ' .. a:cmd)
     let firstline = popup_getpos(a:winid).firstline
-    call popup_setoptions(a:winid, #{firstline: firstline})
+    call popup_setoptions(a:winid, {'firstline': firstline})
 endfunction
 
 function! s:setheight(winid, step) abort
     let height = popup_getoptions(a:winid).minheight
     let newheight = height + a:step > 0 ? height + a:step : 1
-    call popup_setoptions(a:winid, #{minheight: newheight, maxheight: newheight})
+    call popup_setoptions(a:winid, {'minheight': newheight, 'maxheight': newheight})
 endfunction
 
 function! s:popup_filter(winid, key) abort
@@ -81,38 +81,38 @@ function! qfpreview#open(idx) abort
     " Truncate long titles
     if len(title) > wininfo.width
         let width = wininfo.width - 4
-        let title = '…' . title[-width:]
+        let title = '…' .. title[-width:]
     endif
 
     if space_above > height
         if space_above == height + 1
             let height = height - 1
         endif
-        let opts = #{
-                \ line: wininfo.winrow - 1,
-                \ pos: 'botleft'
+        let opts = {
+                \ 'line': wininfo.winrow - 1,
+                \ 'pos': 'botleft'
                 \ }
     elseif space_below >= height
-        let opts = #{
-                \ line: wininfo.winrow + wininfo.height,
-                \ pos: 'topleft'
+        let opts = {
+                \ 'line': wininfo.winrow + wininfo.height,
+                \ 'pos': 'topleft'
                 \ }
     elseif space_above > 5
         let height = space_above - 2
-        let opts = #{
-                \ line: wininfo.winrow - 1,
-                \ pos: 'botleft'
+        let opts = {
+                \ 'line': wininfo.winrow - 1,
+                \ 'pos': 'botleft'
                 \ }
     elseif space_below > 5
         let height = space_below - 2
-        let opts = #{
-                \ line: wininfo.winrow + wininfo.height,
-                \ pos: 'topleft'
+        let opts = {
+                \ 'line': wininfo.winrow + wininfo.height,
+                \ 'pos': 'topleft'
                 \ }
     elseif space_above <= 5 || space_below <= 5
-        let opts = #{
-                \ line: &lines - &cmdheight,
-                \ pos: 'botleft'
+        let opts = {
+                \ 'line': &lines - &cmdheight,
+                \ 'pos': 'botleft'
                 \ }
     else
         echohl ErrorMsg
@@ -121,26 +121,26 @@ function! qfpreview#open(idx) abort
         return
     endif
 
-    call extend(opts, #{
-            \ col: wininfo.wincol,
-            \ minheight: height,
-            \ maxheight: height,
-            \ minwidth: wininfo.width - 1,
-            \ maxwidth: wininfo.width - 1,
-            \ firstline: qfitem.lnum < 1 ? 1 : qfitem.lnum,
-            \ title: title,
-            \ close: 'button',
-            \ padding: [0,1,1,1],
-            \ border: [1,0,0,0],
-            \ borderchars: [' '],
-            \ moved: 'any',
-            \ mapping: s:get('mapping'),
-            \ filter: funcref('s:popup_filter'),
-            \ filtermode: 'n',
-            \ highlight: 'QfPreview',
-            \ borderhighlight: ['QfPreviewTitle'],
-            \ scrollbarhighlight: 'QfPreviewScrollbar',
-            \ thumbhighlight: 'QfPreviewThumb'
+    call extend(opts, {
+            \ 'col': wininfo.wincol,
+            \ 'minheight': height,
+            \ 'maxheight': height,
+            \ 'minwidth': wininfo.width - 1,
+            \ 'maxwidth': wininfo.width - 1,
+            \ 'firstline': qfitem.lnum < 1 ? 1 : qfitem.lnum,
+            \ 'title': title,
+            \ 'close': 'button',
+            \ 'padding': [0,1,1,1],
+            \ 'border': [1,0,0,0],
+            \ 'borderchars': [' '],
+            \ 'moved': 'any',
+            \ 'mapping': s:get('mapping'),
+            \ 'filter': funcref('s:popup_filter'),
+            \ 'filtermode': 'n',
+            \ 'highlight': 'QfPreview',
+            \ 'borderhighlight': ['QfPreviewTitle'],
+            \ 'scrollbarhighlight': 'QfPreviewScrollbar',
+            \ 'thumbhighlight': 'QfPreviewThumb'
             \ })
 
     hi def link QfPreview Pmenu

--- a/autoload/qfpreview.vim
+++ b/autoload/qfpreview.vim
@@ -12,6 +12,11 @@ scriptencoding utf-8
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+hi def link QfPreview           Pmenu
+hi def link QfPreviewTitle      Pmenu
+hi def link QfPreviewScrollbar  PmenuSbar
+hi def link QfPreviewThumb      PmenuThumb
+
 let s:defaults = {
         \ 'height': 15,
         \ 'scrollup': "\<c-k>",
@@ -24,10 +29,7 @@ let s:defaults = {
         \ 'mapping': v:false
         \ }
 
-function! s:get(key) abort
-    let var = get(b:, 'qfpreview', get(g:, 'qfpreview', {}))
-    return has_key(var, a:key) ? var[a:key] : s:defaults[a:key]
-endfunction
+let s:get = {x -> get(b:, 'qfpreview', get(g:, 'qfpreview', {}))->get(x, s:defaults[x])}
 
 let s:mappings = {
         \ 'g': {id -> popup_setoptions(id, {'firstline': 1})},
@@ -143,12 +145,7 @@ function! qfpreview#open(idx) abort
             \ 'thumbhighlight': 'QfPreviewThumb'
             \ })
 
-    hi def link QfPreview Pmenu
-    hi def link QfPreviewTitle Pmenu
-    hi def link QfPreviewScrollbar PmenuSbar
-    hi def link QfPreviewThumb PmenuThumb
-
-    silent call popup_create(qfitem.bufnr, opts)
+    silent return popup_create(qfitem.bufnr, opts)
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/doc/qfpreview.txt
+++ b/doc/qfpreview.txt
@@ -73,9 +73,8 @@ CTRL-F      Scroll the popup window down one full page.
 CTRL-B      Scroll the popup window up one full page.
             Configurable, see |qfpreview.fullpageup| below.
 
-                                                                *qfpreview_gg*
-gg          Jump to first line of displayed buffer.
-            Note: In Vim `8.1.1799` or above a single "g" press is sufficient.
+                                                                 *qfpreview_g*
+g           Jump to first line of displayed buffer.
 
                                                                  *qfpreview_G*
 G           Jump to bottom of displayed buffer.


### PR DESCRIPTION
The current popup-filter works fine as long as the popup window doesn't
display any wrapped lines. It assumes that the height of the text box
[`popup_getpos({id}).core_height`] is equal to the number of displayed
buffer lines. Affected by this are `G`, and `halfpageup`,
`halfpagedown`, `fullpageup` and `fullpagedown` mappings.

The following commit implements proper scrolling that works also for
wrapped lines by executing Normal-mode commands in the popup window.

Note that Normal-mode commands should be avoided and used only as a
fallback. Instead scrolling should be implemented using the
`firstline/lastline` entries. See the following comments by Bram:
 - https://github.com/vim/vim/issues/4882#issuecomment-526954273
 - https://github.com/vim/vim/issues/5170#issuecomment-549566321

Note: `lastline` property was added in patch 8.1.2250.

Related issues:
- https://github.com/vim/vim/issues/5162
- https://github.com/vim/vim/issues/5170