### PR TITLE
Fix neovim crashes

### DIFF
--- a/after/ftplugin/qf.vim
+++ b/after/ftplugin/qf.vim
@@ -1,3 +1,7 @@
+if !has('vim9script') ||  v:version < 900
+    finish
+endif
+
 vim9script
 # ==============================================================================
 # Preview file with quickfix error in a popup window


### PR DESCRIPTION
By adding a check for vim9script the plugin doesn't crash for neovim or older vim versions